### PR TITLE
`catkin_make` fails due to unfortunate submodule configuration.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/openmv"]
-	path = scripts/openmv
-	url = git@github.com:openmv/openmv.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts/openmv"]
+	path = scripts/openmv
+	url = https://github.com/openmv/openmv


### PR DESCRIPTION
```bash
-- +++ processing catkin package: 'l3xz_openmv_camera'
-- ==> add_subdirectory(l3xz_openmv_camera)
-- Submodule update
Submodule 'scripts/openmv' (git@github.com:openmv/openmv.git) registered for path 'scripts/openmv'
Cloning into '/home/alex/projects/107-systems/catkin_ws/src/l3xz_openmv_camera/scripts/openmv'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:openmv/openmv.git' into submodule path '/home/alex/projects/107-systems/catkin_ws/src/l3xz_openmv_camera/scripts/openmv' failed
Failed to clone 'scripts/openmv'. Retry scheduled
Cloning into '/home/alex/projects/107-systems/catkin_ws/src/l3xz_openmv_camera/scripts/openmv'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:openmv/openmv.git' into submodule path '/home/alex/projects/107-systems/catkin_ws/src/l3xz_openmv_camera/scripts/openmv' failed
Failed to clone 'scripts/openmv' a second time, aborting
CMake Error at l3xz_openmv_camera/CMakeLists.txt:19 (message):
  git submodule update --init failed with 1, please checkout submodules


-- Configuring incomplete, errors occurred!
```